### PR TITLE
feat: allow skipping failed runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ jobs:
       - uses: vanstinator/re-run-open-prs-on-base-update@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
+          skip_failed_runs: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   github_token:
     description: "The token to authenticate Octokit. This token will also be used to dispatch worfklow events."
     required: true
+  skip_failured_runs:
+    description: "Sometimes you may have transient failures that you want to debug and you don't want to re-run an action and lose that log context."
+    required: false
 runs:
   using: "node12"
   main: "index.js"

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   github_token:
     description: "The token to authenticate Octokit. This token will also be used to dispatch worfklow events."
     required: true
-  skip_failured_runs:
+  skip_failed_runs:
     description: "Sometimes you may have transient failures that you want to debug and you don't want to re-run an action and lose that log context."
     required: false
 runs:

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ async function dispatchWorkflowEvent(octokit, data) {
 
     if (workflowRun) {
 
-        const skipFailure = core.getInput("skip_failured_runs");
+        const skipFailure = core.getInput("skip_failed_runs");
 
         if (workflowRun.conclusion === 'failure' && !skipFailure) {
             console.log(`Skipping failed run ${data.owner}/${data.repo}/${data.ref}`)

--- a/index.js
+++ b/index.js
@@ -33,8 +33,6 @@ async function waitForCanceledRun(octokit, data) {
         await new Promise(resolve => setTimeout(resolve, 4000));
         let workflowRun = await getWorkflowRunForBranch(octokit, data);
     
-        console.log(JSON.stringify(workflowRun, null, 2));
-
         if (workflowRun && workflowRun.status === 'completed') {
             break;
         }
@@ -47,6 +45,9 @@ async function dispatchWorkflowEvent(octokit, data) {
     let workflowRun = await getWorkflowRunForBranch(octokit, data);
 
     if (workflowRun) {
+
+        console.log(JSON.stringify(workflowRun, null, 2));
+
         if (workflowRun.status !== 'completed') {
             await octokit.actions.cancelWorkflowRun({
                 owner: data.owner,

--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ async function waitForCanceledRun(octokit, data) {
         await new Promise(resolve => setTimeout(resolve, 4000));
         let workflowRun = await getWorkflowRunForBranch(octokit, data);
     
+        console.log(JSON.stringify(workflowRun, null, 2));
+
         if (workflowRun && workflowRun.status === 'completed') {
             break;
         }

--- a/index.js
+++ b/index.js
@@ -46,6 +46,13 @@ async function dispatchWorkflowEvent(octokit, data) {
 
     if (workflowRun) {
 
+        const skipFailure = core.getInput("skip_failured_runs");
+
+        if (workflowRun.conclusion === 'failure' && !skipFailure) {
+            console.log(`Skipping failed run ${data.owner}/${data.repo}/${data.ref}`)
+            return;
+        }
+
         console.log(JSON.stringify(workflowRun, null, 2));
 
         if (workflowRun.status !== 'completed') {
@@ -95,6 +102,7 @@ async function dispatchWorkflowEventToGithub(opts) {
     }
 
     const octokit = new Octokit({ auth: opts.token });
+
 
     return dispatchWorkflowEvent(octokit, data);
 }

--- a/index.js
+++ b/index.js
@@ -101,7 +101,6 @@ async function dispatchWorkflowEventToGithub(opts) {
 
     const octokit = new Octokit({ auth: opts.token });
 
-
     return dispatchWorkflowEvent(octokit, data);
 }
 

--- a/index.js
+++ b/index.js
@@ -46,14 +46,12 @@ async function dispatchWorkflowEvent(octokit, data) {
 
     if (workflowRun) {
 
-        const skipFailure = core.getInput("skip_failed_runs");
+        const skipFailedRuns = core.getInput("skip_failed_runs");
 
-        if (workflowRun.conclusion === 'failure' && !skipFailure) {
+        if (workflowRun.conclusion === 'failure' && skipFailedRuns) {
             console.log(`Skipping failed run ${data.owner}/${data.repo}/${data.ref}`)
             return;
         }
-
-        console.log(JSON.stringify(workflowRun, null, 2));
 
         if (workflowRun.status !== 'completed') {
             await octokit.actions.cancelWorkflowRun({


### PR DESCRIPTION
Github Actions eats logs from previous instances of a workflow run when it's re-run a second time. When you're debugging transient errors in CI this can be painful. Adding a configuration switch to this flow will make it much easier to toggle this behavior on and off.